### PR TITLE
fix: empty env vars to trigger pw query

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-TOGGL_API_TOKEN=your_token_here
-JIRA_TOKEN=your_jira_token_here
+TOGGL_API_TOKEN=
+JIRA_TOKEN=


### PR DESCRIPTION
Invalid values are causing 401 but we want to ask for a username and pw when no jira token is given